### PR TITLE
DPF再生中の表示を修正

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -255,7 +255,8 @@ static void display_additional_meter() {
             sprite.setTextColor( RED );
         }
         sprite.printf( "DPF" );
-
+        
+        sprite.setTextColor( WHITE );
         SET_FONT_AND_SIZE( FreeMono9pt7b, 1 );
         sprite.setCursor( 15, 80 );
         sprite.printf( "Accum" );


### PR DESCRIPTION
## 変更内容
DPF再生中に画面全体が赤く表示され見にくくなっていたので、DPFの表示部分のみを赤く表示するように変更しました
